### PR TITLE
Update rubyzip version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ spec/reports
 test/tmp
 test/version_tmp
 tmp
+.idea

--- a/ruby_powerpoint.gemspec
+++ b/ruby_powerpoint.gemspec
@@ -25,5 +25,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec', '~> 3'
 
   spec.add_dependency 'nokogiri', '~> 1.6'
-  spec.add_dependency 'rubyzip', '~> 1.0'
+  spec.add_dependency 'rubyzip', '~> 2.0'
 end


### PR DESCRIPTION
Version up `rubyzip`. All tests passed.
I'd like to use other gem which depends on `rubyzip ~> 2.0`.